### PR TITLE
remove version from typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for rejection-sampled-int 0.2.1
+// Type definitions for rejection-sampled-int
 // Project: rejection-sampled-int
 // Definitions by: Nathan Wittstock <fardog.io>
 


### PR DESCRIPTION
there's no need to have this in the file; it's shipped with the library and is one more thing to forget to update